### PR TITLE
Add a CHANGELOG for Moore cluster datapackage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Moore datapackage changelog
+
+All notable changes to Moore cluster datapackages is documented in this file.
+
+The format is based on [Keep a Changelog](https://github.com/olivierlacan/keep-a-changelog/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.8.0 - 2025-08-22
+
+### Added
+
+- Add column `CB_CALIB_GROUPS` to spatial dapackage.
+- Add CHANGELOG.md link to README.md


### PR DESCRIPTION
As in title. A link to this CHANGELOG will be added to Moore cluster datapackage README.

Note: For now we only have one Moore cluster datapackage, so there's no ambiguity about this CHANGELOG. If we start to maintain more datapackages (either for other reef clusters in the GBR, for the whole GBR or for Reefs outside the GBR), we will need to either keep a separate CHANGELOG for each one or have separate sections in side this CHANGELOG for all of them. 